### PR TITLE
Updated MANIFEST.in to include resources for RU (and excluded EN)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include errant/en/resources/*
+include errant/ru/resources/*


### PR DESCRIPTION
Hello!

First of all, thank you for adapting ERRANT to Russian, I find this very useful.

I came across two problems when using this implementation:

1. When installing from source via pip-install (`pip install git+https://github.com/Askinkaty/errant/@4183e57`) the installation does not fetch resource files for Russian, but for English. I suggest a fix in this pull request, which is changing `MANIFEST.in`.
2. Importing the classifier for Russian raises an error of missing frequency dict: https://github.com/Askinkaty/errant/blob/4183e5754dc462d606f6acece072790aec316539/errant/ru/classifier.py#L37 
So, maybe the file has been lost during the code publication, and you could provide it? If not, as far as I can see, this dict is used only once in the further processing, so maybe one should comment out its loading and never use it?

Anyway, I’d like to contribute to the problem solution, so your comment would be helpful.